### PR TITLE
Fix duplicate link reference in async driver post

### DIFF
--- a/_posts/2015-04-01-async-drivers.md
+++ b/_posts/2015-04-01-async-drivers.md
@@ -127,8 +127,6 @@ realtime Ruby app with [Faye][] and RethinkDB. Faye is an open source
 publish/subscribe framework that includes a backend server component and a
 frontend JavaScript library that runs in the web browser.
 
-[Faye][]: http://faye.jcoglan.com/
-
 Faye makes it easy to do realtime messaging between client and server. It uses
 WebSockets where available, but can also fall back on long polling.  My simple
 demo app is a realtime todo list. When any user adds a new item to the list or


### PR DESCRIPTION
There's a previous link definition for `[Faye][]` earlier in the file. The way that it is included here causes the hanging link to show up in the article, which is undesirable.
