### PR TITLE
CPU/memory utilization improvements using `d3.timer`

### DIFF
--- a/assets/js/landing.coffee
+++ b/assets/js/landing.coffee
@@ -80,7 +80,7 @@ add_realtime_message = (ret) ->
       # Bump up the score cap
       score_cap = score_cap + 1
 
-      if ret == false
+      if ret is false
         d3.timer(add_realtime_message(false), 3000)
 
       return true
@@ -178,8 +178,8 @@ draw_ui_graph = ->
                 .duration(update_freq)
                 .attr('transform', "translate(#{x(0)})")
 
-        d3.timer(createNextFunction(), update_freq+200)
+        d3.timer(createNextFunction(), update_freq)
         return true
 
     #Start the line animation loop here.
-    d3.timer(createNextFunction(), update_freq+200);
+    d3.timer(createNextFunction(), update_freq);


### PR DESCRIPTION
https://github.com/mbostock/d3/wiki/Transitions#timers

Removed the `setInterval` functions from `landing.coffee` and replaced them with the more efficient D3 timer. Anecdotal evidence on my machine seems that things are a bit better. 

I think this will improve #71 

@danielmewes 
