### PR TITLE
Fixing RSS bug since we never actually set the `author.name` value in posts

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -4,15 +4,15 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
     <channel>
         <title>{{ site.rss.name | xml_escape }}</title>
-        <description>{% if site.rss.description %}{{ site.rss.description | xml_escape }}{% endif %}</description>		
+        <description>{% if site.rss.description %}{{ site.rss.description | xml_escape }}{% endif %}</description>
         <link>{{ site.rss.url }}</link>
         <atom:link href="{{ site.rss.url }}/feed.xml" rel="self" type="application/rss+xml" />
         {% for post in site.posts %}
         <item>
             <title>{{ post.title | xml_escape }}</title>
-            {% if post.author.name %}
-            <dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
-            {% endif %}        
+            {% if post.author %}
+            <dc:creator>{{ post.author | xml_escape }}</dc:creator>
+            {% endif %}
             <description>
                 <![CDATA[
                 {% if post.hero_image %}


### PR DESCRIPTION
Need this commit pushed for RSS eating by the Mailchimp
