### PR TITLE
fix: internal link to /docs/install-drivers

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -18,7 +18,7 @@ permalink: /contribute/
             <li>Identify, report, triage, and fix bugs in RethinkDB and its subprojects</li>
             <li>Draft and edit documentation for RethinkDB and its subprojects</li>
             <li>Maintain and improve our testing and build tooling</li>
-            <li>Develop and maintain client libraries for various programming languages (JavaScript, Python, Ruby, Java, and <a href="http://localhost:8888/docs/install-drivers/">many more</a> languages)</li>
+            <li>Develop and maintain client libraries for various programming languages (JavaScript, Python, Ruby, Java, and <a href="/docs/install-drivers/">many more</a> languages)</li>
             <li>Build integrations between RethinkDB and useful third-party software</li>
             <li>Build libraries and frameworks for RethinkDB users</li>
         </ul>


### PR DESCRIPTION
**Reason for the change**
Looks like 'many more' link on https://rethinkdb.com/contribute is pointing to a localhost location. This PR fixes that link and points to the correct location.

**Description**
Replaced localhost link with the correct link to that page.

**Code examples**
N/A

**Checklist**
- [X] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
Page that has a broken link: https://rethinkdb.com/contribute

