### PR TITLE
Update keyserver to keyserver.ubuntu.com

### DIFF
--- a/_posts/2020-05-21-download-server-changes.md
+++ b/_posts/2020-05-21-download-server-changes.md
@@ -18,7 +18,7 @@ Generally speaking, the new repository schema will look like `https://download.r
 To install RethinkDB from an APT repository, you will need to run the following:
 
 ```bash
-$ apt-key adv --keyserver keys.gnupg.net --recv-keys "539A 3A8C 6692 E6E3 F69B 3FE8 1D85 E93F 801B B43F"
+$ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A 3A8C 6692 E6E3 F69B 3FE8 1D85 E93F 801B B43F"
 $ echo "deb https://download.rethinkdb.com/repository/$APT_REPOSITORY $DISTRIBUTION_NAME main" > /etc/apt/sources.list.d/rethinkdb.list
 $ sudo apt-get update
 $ sudo apt-get install rethinkdb
@@ -28,7 +28,7 @@ Compared to the previous installation method, the only change is in line 2. You 
 As an example, it would look like the following for ubuntu-focal:
 
 ```bash
-$ apt-key adv --keyserver keys.gnupg.net --recv-keys "539A 3A8C 6692 E6E3 F69B 3FE8 1D85 E93F 801B B43F"
+$ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A 3A8C 6692 E6E3 F69B 3FE8 1D85 E93F 801B B43F"
 $ echo "deb https://download.rethinkdb.com/repository/ubuntu-focal focal main" > /etc/apt/sources.list.d/rethinkdb.list
 $ sudo apt-get update
 $ sudo apt-get install rethinkdb


### PR DESCRIPTION
Change keys.gnupg.net (no longer active) to keyserver.ubuntu.com.

**Reason for the change**
If applicable, link the related issue/bug report or write down in few sentences the motivation.

**Description**
A clear and concise description of what did you changed and why.

**Code examples**
If applicable, add code examples to help explain your changes.

**Checklist**
- [ ] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
Anything else related to the change e.g. documentations, RFCs, etc.
